### PR TITLE
Update requirements for Contao 4.9 and PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,8 @@
     }
   ],
   "require": {
-    "php": "^7.1",
-    "contao/core-bundle": "^4.4",
-    "contao-community-alliance/contao-polyfill-bundle": "^1.1"
+    "php": "^7.1 || ^8.0",
+    "contao/core-bundle": "^4.9"
   },
   "require-dev": {
     "contao/manager-plugin": "^2.2"


### PR DESCRIPTION
Update requirements for Contao 4.9 and PHP 8